### PR TITLE
Fix Defending Exploit

### DIFF
--- a/Dark-And-Under/DarkUnder_Battle.ino
+++ b/Dark-And-Under/DarkUnder_Battle.ino
@@ -143,7 +143,7 @@ GameState battlePlayerDecides(void)
   for(uint8_t i = 0; i < fightButtonsCount; ++i) {
 
     if(fightButtons[i])
-      arduboy.drawCompressed(80 + 11 * i, 44, pgm_read_word(&fight_actions[i]), WHITE);
+      arduboy.drawCompressed(80 + 11 * i, 44, static_cast<const uint8_t *>(pgm_read_ptr(&fight_actions[i])), WHITE);
 
   }
   

--- a/Dark-And-Under/DarkUnder_Battle.ino
+++ b/Dark-And-Under/DarkUnder_Battle.ino
@@ -94,7 +94,7 @@ GameState battleEnemyAttacks(void) {
   font3x5.print(F(" DAMAGE!"));
   font3x5.setCursor(33, 26);
   font3x5.print(hpLoss);
-  myHero.setHitPoints(myHero.getHitPoints() > hpLoss ? myHero.getHitPoints() - hpLoss : 0);
+  myHero.takeDamage(hpLoss);
 
   return (myHero.getHitPoints() > 0)
   ? GameState::Battle_PlayerDecides
@@ -244,7 +244,7 @@ GameState battlePlayerDefends(void) {
   font3x5.setCursor(17, 35);
   font3x5.print(hpLoss);
 
-  myHero.setHitPoints(myHero.getHitPoints() - hpLoss);
+  myHero.takeDamage(hpLoss);
   damageEnemy(attackingEnemyIdx, 1);
 
   return (enemies[attackingEnemyIdx].getEnabled())

--- a/Dark-And-Under/DarkUnder_Battle.ino
+++ b/Dark-And-Under/DarkUnder_Battle.ino
@@ -96,9 +96,9 @@ GameState battleEnemyAttacks(void) {
   font3x5.print(hpLoss);
   myHero.takeDamage(hpLoss);
 
-  return (myHero.getHitPoints() > 0)
-  ? GameState::Battle_PlayerDecides
-  :  GameState::Battle_PlayerDies;
+  return (myHero.isDead())
+  ? GameState::Battle_PlayerDies
+  : GameState::Battle_PlayerDecides;
 }
 
 GameState battleEnemyDies(void)

--- a/Dark-And-Under/DarkUnder_Battle.ino
+++ b/Dark-And-Under/DarkUnder_Battle.ino
@@ -247,6 +247,9 @@ GameState battlePlayerDefends(void) {
   myHero.takeDamage(hpLoss);
   damageEnemy(attackingEnemyIdx, 1);
 
+  if(myHero.isDead())
+    return GameState::Battle_PlayerDies;
+
   return (enemies[attackingEnemyIdx].getEnabled())
   ? GameState::Battle_PlayerDecides
   : GameState::Battle_EnemyDies;

--- a/Dark-And-Under/src/entities/Player.cpp
+++ b/Dark-And-Under/src/entities/Player.cpp
@@ -18,6 +18,12 @@ void Player::setAttackPower(const uint8_t value)          { _attackPower = value
 void Player::setExperiencePoints(const uint8_t value)     { _experiencePoints = value; }
 void Player::setDirection(const Direction value)          { _direction = value; }
 
+void Player::takeDamage(uint8_t amount) {
+
+  _hitPoints = (amount < _hitPoints) ? (_hitPoints - amount) : 0;
+
+}
+
 void Player::setInventory(const int8_t slot, const ItemType item) { 
 
   _inventory[slot] = item; 

--- a/Dark-And-Under/src/entities/Player.cpp
+++ b/Dark-And-Under/src/entities/Player.cpp
@@ -5,6 +5,8 @@
 
 Player::Player() : Base() { }
 
+bool Player::isDead() { return (_hitPoints == 0); }
+
 uint8_t Player::getHitPoints()                            { return _hitPoints; }
 uint8_t Player::getDefence()                              { return _defence; }
 uint8_t Player::getAttackPower()                          { return _attackPower; }

--- a/Dark-And-Under/src/entities/Player.h
+++ b/Dark-And-Under/src/entities/Player.h
@@ -10,6 +10,8 @@ class Player : public Base {
 
     Player();
 
+    bool isDead();
+
     uint8_t getHitPoints();
     uint8_t getDefence();
     uint8_t getAttackPower();

--- a/Dark-And-Under/src/entities/Player.h
+++ b/Dark-And-Under/src/entities/Player.h
@@ -28,6 +28,8 @@ class Player : public Base {
     
     void setInventory(const int8_t slot, const ItemType item);   
     void setDirection(const Direction value);
+
+    void takeDamage(uint8_t amount);
      
   private:
 


### PR DESCRIPTION
Fixes #28.

This PR fixes the problem by:
* Preventing health from underflowing using a new `takeDamage` function
* Properly detecting that a player has died in the process of defending (using a new `isDead` function)

If the second point is undesirable then I can make a new PR that includes the fix for underflow but still makes the player effectively 'immortal' when defending, though I presume that behaviour would be undesirable.